### PR TITLE
[DESSERTS-19] Question API 예외처리 구현

### DIFF
--- a/api-core/build.gradle
+++ b/api-core/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+}

--- a/api-core/src/main/java/com/weecode/desserts/CommonControllerAdvice.java
+++ b/api-core/src/main/java/com/weecode/desserts/CommonControllerAdvice.java
@@ -1,0 +1,31 @@
+package com.weecode.desserts;
+
+import com.weecode.desserts.common.dto.DessertsResponse;
+import com.weecode.desserts.common.dto.ErrorMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static com.weecode.desserts.CommonControllerAdvice.COMMON_ADVICE_PRIORITY;
+
+@Slf4j
+@RestControllerAdvice
+@Order(COMMON_ADVICE_PRIORITY)
+public class CommonControllerAdvice {
+    public static final int COMMON_ADVICE_PRIORITY = 99;
+
+    @ExceptionHandler(RuntimeException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public DessertsResponse<ErrorMessage> handleInternalServerError(Exception exception) {
+        log.error("error occured. {}", exception.getMessage(), exception);
+
+        return DessertsResponse.fail(
+                ErrorMessage.builder()
+                        .message("일시적으로 오류가 발생했습니다.")
+                        .build()
+        );
+    }
+}

--- a/api-core/src/main/java/com/weecode/desserts/common/dto/DessertsResponse.java
+++ b/api-core/src/main/java/com/weecode/desserts/common/dto/DessertsResponse.java
@@ -17,4 +17,8 @@ public class DessertsResponse<T> {
     public static <T> DessertsResponse<T> success(T data) {
         return new DessertsResponse<>(data);
     }
+
+    public static DessertsResponse<ErrorMessage> fail(ErrorMessage errorMessage) {
+        return new DessertsResponse<>(errorMessage);
+    }
 }

--- a/api-core/src/main/java/com/weecode/desserts/common/dto/ErrorMessage.java
+++ b/api-core/src/main/java/com/weecode/desserts/common/dto/ErrorMessage.java
@@ -1,0 +1,18 @@
+package com.weecode.desserts.common.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ErrorMessage {
+
+    private String message;
+
+    @Builder
+    private ErrorMessage(String message) {
+        this.message = message;
+    }
+}

--- a/api-core/src/main/java/com/weecode/desserts/exception/DessertsException.java
+++ b/api-core/src/main/java/com/weecode/desserts/exception/DessertsException.java
@@ -1,0 +1,8 @@
+package com.weecode.desserts.exception;
+
+public class DessertsException extends RuntimeException {
+
+    public DessertsException(String message) {
+        super(message);
+    }
+}

--- a/external-api/build.gradle
+++ b/external-api/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    implementation project(':core')
+    implementation project(':api-core')
     implementation project(':domain')
     implementation 'org.springframework.boot:spring-boot-starter-web'
 

--- a/external-api/src/main/java/com/weecode/desserts/external/question/QuestionApiController.java
+++ b/external-api/src/main/java/com/weecode/desserts/external/question/QuestionApiController.java
@@ -23,7 +23,6 @@ public class QuestionApiController {
     @GetMapping
     public CompletableFuture<DessertsResponse<QuestionsResponse>> questions(Pageable pageable) {
         return questionService.readQuestions(pageable)
-                .thenCompose(questionsResponse ->
-                        CompletableFuture.supplyAsync(() -> DessertsResponse.success(questionsResponse)));
+                .thenCompose(questionsResponse -> CompletableFuture.supplyAsync(() -> DessertsResponse.success(questionsResponse)));
     }
 }

--- a/external-api/src/test/java/com/weecode/desserts/external/question/QuestionApiControllerTest.java
+++ b/external-api/src/test/java/com/weecode/desserts/external/question/QuestionApiControllerTest.java
@@ -6,12 +6,15 @@ import com.weecode.desserts.common.dto.DessertsResponse;
 import com.weecode.desserts.domain.question.Question;
 import com.weecode.desserts.domain.question.QuestionRepository;
 import com.weecode.desserts.external.dummy.QuestionDummyBuilder;
+import com.weecode.desserts.external.question.component.QuestionResponseConverter;
 import com.weecode.desserts.external.question.dto.QuestionsResponse;
 import com.weecode.desserts.test.ContextTest;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -19,9 +22,13 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureMockMvc
 class QuestionApiControllerTest extends ContextTest {
@@ -34,6 +41,9 @@ class QuestionApiControllerTest extends ContextTest {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @SpyBean
+    private QuestionResponseConverter questionResponseConverter;
 
 
     @Test
@@ -63,5 +73,26 @@ class QuestionApiControllerTest extends ContextTest {
         QuestionsResponse data = actual.getData();
         assertNotNull(data);
         assertThat(data.getQuestions()).hasSize(20);
+    }
+
+    @Test
+    @DisplayName("서버 에러 발생시 500응답과 함께 메세지를 띄워준다.")
+    void readQuestions_ifOccurredServerException_thenResponseInternalServerException() throws Exception {
+        // given
+        List<Question> questions = QuestionDummyBuilder.create(50);
+        questionRepository.saveAll(questions);
+        given(questionResponseConverter.convert(anyList())).willThrow(RuntimeException.class);
+
+        // when
+        MvcResult result = mockMvc.perform(
+                get("/v1/questions")
+                        .queryParam("page", "0")
+        )
+                .andDo(print())
+                .andReturn();
+
+        mockMvc.perform(asyncDispatch(result))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.data.message").value(Matchers.is("일시적으로 오류가 발생했습니다.")));
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,9 +1,10 @@
 rootProject.name = 'desserts'
 
+include 'core'
 include 'core-test'
-include 'domain'
+include 'api-core'
 include 'infrastructures'
 include 'infrastructures:rdb'
-include 'core'
+include 'domain'
 include 'external-api'
 


### PR DESCRIPTION
[DESSERTS-19] Question API 예외처리 구현

`/v1/questions`에서 예외가 발생할만한 부분은 서버 측에서 에러가 발생한 경우 밖에 없음.
이때, 서버 에러 처리는 다른 API에서도 공통적인 사항이므로  `api-core` 모듈에 정의하여 다른 API에도 서버 에러에 대해서는 예외처리가 가능하도록 설계

[DESSERTS-19]: https://pkch.atlassian.net/browse/DESSERTS-19